### PR TITLE
bugfix: add new option lint-timeout to allow configure timeout for ru…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v4.1.3] - 2022-9-21
+
+### Updated
+
+- added new option for golangci-lint `lint-timeout` in go-ci action
+
 ## [v4.1.2] - 2022-9-15
 
 ### Updated

--- a/go-ci/action.yml
+++ b/go-ci/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "Should the action run the gosec action (default: `false`)"
     required: false
     default: "false"
+  lint-timeout:
+    description: "Set timeout for lint the code (default: 3m0s)"
+    required: false
+    default: "3m0s"
 
 runs:
   using: "composite"
@@ -54,7 +58,7 @@ runs:
       with:
         version: latest
         only-new-issues: true
-        args: --issues-exit-code=0
+        args: --issues-exit-code=0 --timeout=${{ inputs.lint-timeout }}
 
     - name: Test
       shell: bash

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version=4.1.2
+version=4.1.3


### PR DESCRIPTION
Regardings to the failed job in: https://github.com/parsleyhealth/emr-service/actions/runs/3102216591/jobs/5024956247

I would like to add a new option `lint-timeout` for go-ci action to allow setup timeout for running the golangci-lint.