### PR TITLE
Add test-cmd optional to execute custom test command in go-ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v4.2.2] - 2022-11-07
+### Added
+
+- New optional for test command to execute with custom test command for `go-ci`
+
 ## [v4.2.1] - 2022-10-5
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v4.2.2] - 2022-11-07
+## [v4.3] - 2022-11-07
 ### Added
 
 - New optional for test command to execute with custom test command for `go-ci`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v4.3] - 2022-11-07
+## [v4.3.0] - 2022-11-07
 ### Added
 
 - New optional for test command to execute with custom test command for `go-ci`

--- a/go-ci/README.md
+++ b/go-ci/README.md
@@ -21,9 +21,9 @@ jobs:
         platform: [ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run lint, test, coverage
-      uses: parsleyhealth/composite-actions/go-ci@v3
+      uses: parsleyhealth/composite-actions/go-ci@v4
       with:
         go-version: ${{ matrix.go-version }}
         pat: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
@@ -32,6 +32,7 @@ jobs:
         sonar-project-key: super-awesome-service
         run-lint: "true"
         run-gosec: "true"
+        test-cmd: "go test ./... -coverprofile=coverage.out"
 
 ```
 
@@ -44,3 +45,4 @@ jobs:
 - **sonar-project-key**: Project key to identify source in sonar dash (required)
 - **run-lint**: Should the action run lint on the code (default: `true`)
 - **run-gosec**: Should the action run the gosec on the code (default: `false`)
+- **test-cmd**: Should override the test command (default :`go test ./... -coverprofile=coverage.out`)

--- a/go-ci/action.yml
+++ b/go-ci/action.yml
@@ -30,6 +30,12 @@ inputs:
     description: "Set timeout for lint the code (default: 3m0s)"
     required: false
     default: "3m0s"
+  test-cmd:
+    description: "Test command to execute test"
+    required: false
+    default: "go test ./... -coverprofile=coverage.out"
+
+  
 
 runs:
   using: "composite"
@@ -62,7 +68,7 @@ runs:
 
     - name: Test
       shell: bash
-      run: go test ./... -coverprofile=coverage.out
+      run: ${{ inputs.test-cmd }}
 
     - name: Gosec
       uses: securego/gosec@master

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version=4.2.2
+version=4.3

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version=4.3
+version=4.3.0

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version=4.2.1
+version=4.2.2


### PR DESCRIPTION
Hi @chiefy,

I would like to add a new option to allow the go-ci to execute a custom test command. Some repos need to run integration tests by executing a custom command. Could you please help me review it?

Thanks & Best Regards