### PR TITLE
feat: add setup-node, bump version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,16 @@ jobs:
           gcp-project-id: ${{ secrets.GCP_PROJECT_ID}}
           gcp-workload-id-provider: ${{ secrets.GCP_WORKLOAD_ID_PROVIDER }}
           gcp-workload-id-service-account-email: ${{ secrets.GCP_WORKLOAD_ID_SA_EMAIL }}
+
+      - name: Setup Node.js good test
+        uses: ./setup-node
+        with:
+          node-version: "lts/hydrogen"
+          npm-token: "fakefakefake"
+          bit-token: "fakefakefake"
+
+      - name: Setup Node.js bad test (no tokens provided)
+        continue-on-error: true
+        uses: ./setup-node
+        with:
+          node-version: "lts/hydrogen"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ defaults:
     shell: bash
 
 jobs:
-  test-build-push-action:
+  test-actions:
     permissions:
       contents: "read"
       id-token: "write"
@@ -30,15 +30,15 @@ jobs:
           gcp-workload-id-provider: ${{ secrets.GCP_WORKLOAD_ID_PROVIDER }}
           gcp-workload-id-service-account-email: ${{ secrets.GCP_WORKLOAD_ID_SA_EMAIL }}
 
+      - name: Setup Node.js bad test (no tokens provided)
+        continue-on-error: true
+        uses: ./setup-node
+        with:
+          node-version: "lts/hydrogen"
+
       - name: Setup Node.js good test
         uses: ./setup-node
         with:
           node-version: "lts/hydrogen"
           npm-token: "fakefakefake"
           bit-token: "fakefakefake"
-
-      - name: Setup Node.js bad test (no tokens provided)
-        continue-on-error: true
-        uses: ./setup-node
-        with:
-          node-version: "lts/hydrogen"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "build-push-action/*"
+      - "setup-node/*"
 
 defaults:
   run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v4.4.0] - 2022-11-09
+
+### Added
+
+- `setup-nodejs` composite action to reduce confusion and DRY in repos that need bit.dev/etc.
+
 ## [v4.3.0] - 2022-11-07
+
 ### Added
 
 - New optional for test command to execute with custom test command for `go-ci`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Utility composite and docker actions for Parsley Workflows
 - [`go-ci`](./go-ci/README.md) common CI patterns for running test, lint and sonar scans on go services
 - [`release-notes`](./release-notes/README.md) push release notes from our core products to a Notion database
 - [`goose-migration`](./goose-migration/README.md) run goose migrations against cloud sql instances
+- [`setup-node`](./setup-node/README.md) replacement for `actions/setup-node`
 
 ## Contributing
 

--- a/setup-node/README.md
+++ b/setup-node/README.md
@@ -1,0 +1,39 @@
+# setup-node
+
+Composite Github Action that sets up Node.js and injects private repo keys to .npmrc file. Use this instead of [`actions/setup-node`](https://github.com/actions/setup-node) (this composite uses it under-the-hood).
+
+## Usage
+
+```yaml
+name: Some Deploy Thing
+on:
+  push:
+    branches:
+      - master
+env:
+    NPM_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+    BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup Node.js with version 19.0.1
+      uses: parsleyhealth/github-composite-actions/setup-nodejs@v4
+      with:
+        node-version: "19.0.1"
+    
+    - name: Setup Node.js with default node version but override bit-token
+      uses: parsleyhealth/github-composite-actions/setup-nodejs@v4
+      with:
+        bit-token: ${{ secrets.OTHER_BIT_TOKEN }}
+
+```
+
+## Inputs
+
+- **node-version**: Node.js version to install, defaults to `lts/gallium`, [reference other versions here](https://nodejs.org/en/download/releases/)
+- **npm-token**: Private repo access token, defaults to use injected environment variable `NPM_TOKEN`, will error if neither are set
+- **bit-token**: Private bit.dev repo access token, defaults to use injected environment variable `BIT_TOKEN`, will error if neither are set

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -1,0 +1,46 @@
+name: "Setup Node.js"
+description: "setup local npmrc for yarn and npm installs of private packages and bit.dev components"
+inputs:
+  node-version:
+    description: "Node version to use (default: `lts/gallium`)"
+    required: false
+    default: "lts/gallium"
+  npm-token:
+    description: "Token to access private npm repo, uses environment var `NPM_TOKEN` if not passed in explicitly"
+    required: false
+    default: ""
+  bit-token:
+    description: "Token to access private npm repo, uses environment var `BIT_TOKEN` if not passed in explicitly"
+    required: false
+    default: ""
+
+outputs: {}
+
+runs:
+  using: composite
+  steps:
+    - name: if tokens provided, override env vars
+      shell: bash
+      run: |
+        if [ ! -z "${{ inputs.npm-token }}" ]; then 
+          echo "NPM_TOKEN=${{ inputs.npm-token }}" >> $GITHUB_ENV 
+        fi
+        if [ ! -z "${{ inputs.bit-token }}" ]; then 
+          echo "BIT_TOKEN=${{ inputs.bit-token }}" >> $GITHUB_ENV 
+        fi
+        if [ -z $NPM_TOKEN ] || [ -z $BIT_TOKEN ]; then 
+          echo "Couldn't find NPM_TOKEN or BIT_TOKEN environment variables, exiting."
+          exit 1
+        fi
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        registry-url: "https://npm.pkg.github.com"
+
+    - name: setup .npmrc for bit.dev
+      shell: bash
+      run: |
+        npm config set @ph-bit:registry=https://node.bit.cloud
+        npm config set //node.bit.cloud/:_authToken ${BIT_TOKEN}
+        npm config set //npm.pkg.github.com/:_authToken ${NPM_TOKEN}

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -28,6 +28,10 @@ runs:
         if [ ! -z "${{ inputs.bit-token }}" ]; then 
           echo "BIT_TOKEN=${{ inputs.bit-token }}" >> $GITHUB_ENV 
         fi
+
+    - name: check for env vars
+      shell: bash
+      run: |
         if [ -z $NPM_TOKEN ] || [ -z $BIT_TOKEN ]; then 
           echo "Couldn't find NPM_TOKEN or BIT_TOKEN environment variables, exiting."
           exit 1

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version=4.3.0
+version=4.4.0


### PR DESCRIPTION
- add new `setup-node` action to help reduce cruft and confusion with setting up private repos