### PR TITLE
feat: print the output of `bit tag —persist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v5.1.0] - 2022-12-23
+
+### Fixed
+
+- Print the output of bit tag —persist
+
 ## [v5.0.3] - 2022-12-01
 
 ### Fixed

--- a/bit-tag-export/docker/entrypoint.sh
+++ b/bit-tag-export/docker/entrypoint.sh
@@ -14,6 +14,8 @@ bit tag --persist >${BIT_CHANGES_OUTPUT_FILE}
 
 echo "BIT_CHANGES=$(cat ${BIT_CHANGES_OUTPUT_FILE} | grep '     > ' | sed 's/     > />/g' | tr '\n' ',' | sed 's/,/\\n/g')" >>${GITHUB_ENV}
 
+cat ${BIT_CHANGES_OUTPUT_FILE}
+
 rm -f ${BIT_CHANGES_OUTPUT_FILE}
 
 bit export

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version=5.0.3
+version=5.1.0


### PR DESCRIPTION
The output of the `bit tag --persist` is captured and parsed for Slack updates but the output is not printed to the log so errors have been obscured.