### PR TITLE
modified Dockerfile, to fix the issue with Docker build failure cause…

### DIFF
--- a/bit-tag-export/docker/Dockerfile
+++ b/bit-tag-export/docker/Dockerfile
@@ -1,16 +1,20 @@
 # Use the official Node.js 18 image with Debian Bullseye (slim)
 FROM node:18-bullseye-slim
 
-# Install Bit CLI
+# Install Bit CLI and other dependencies
 RUN npm install -g @teambit/bvm && \
-    bit config set analytics_reporting false && \
+    npm install -g @teambit/bit
+
+# Set Bit configurations
+RUN bit config set analytics_reporting false && \
     bit config set error_reporting false
 
 # Set the entrypoint to run the action script
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Copy the entrypoint script into the image
 COPY entrypoint.sh /entrypoint.sh
 
 USER root
 RUN chmod +x /entrypoint.sh
 USER user
-
-ENTRYPOINT ["/entrypoint.sh"]

--- a/bit-tag-export/docker/Dockerfile
+++ b/bit-tag-export/docker/Dockerfile
@@ -3,7 +3,6 @@ FROM node:18-bullseye-slim
 
 # Install Bit CLI and other dependencies
 RUN npx @teambit/bvm install < /dev/null
-RUN npm install -g @teambit/bit
 
 # Set Bit configurations
 RUN bit config set analytics_reporting false && \

--- a/bit-tag-export/docker/Dockerfile
+++ b/bit-tag-export/docker/Dockerfile
@@ -2,8 +2,8 @@
 FROM node:18-bullseye-slim
 
 # Install Bit CLI and other dependencies
-RUN npm install -g @teambit/bvm && \
-    npm install -g @teambit/bit
+RUN npx @teambit/bvm install < /dev/null
+RUN npm install -g @teambit/bit
 
 # Set Bit configurations
 RUN bit config set analytics_reporting false && \
@@ -18,3 +18,6 @@ COPY entrypoint.sh /entrypoint.sh
 USER root
 RUN chmod +x /entrypoint.sh
 USER user
+
+# Add a health check command
+HEALTHCHECK CMD node --version || exit 1


### PR DESCRIPTION
…d by the command /bin/sh -c npm install -g @teambit/bvm && bit config set analytics_reporting false && bit config set error_reporting false.

Docker build failed with exit code 127. This error is caused by the command /bin/sh -c npm install -g @teambit/bvm && bit config set analytics_reporting false && bit config set error_reporting false.

The crucial portion of the error message is bit: not found, indicating that the bit command is unavailable in the Docker container during the build. The Bit CLI is not installed in the official Node.js 18 image used as the Dockerfile's base image.

To remedy this issue, we must ensure that the Bit CLI is installed correctly in the Docker container during the build. 
