### PR TITLE
modified Dockerfile, update to Use the bit CLI installation script in…

### DIFF
--- a/bit-tag-export/docker/Dockerfile
+++ b/bit-tag-export/docker/Dockerfile
@@ -1,6 +1,9 @@
 # Use the official Node.js 18 image with Debian Bullseye (slim)
 FROM node:18-bullseye-slim
 
+# Install required dependencies
+RUN apt update && apt install -y curl
+
 # Install Bit CLI and other dependencies
 RUN npx @teambit/bvm install < /dev/null
 
@@ -16,6 +19,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 USER user
+
+# Add Bit CLI to the PATH
+ENV PATH="/root/.bvm:${PATH}"
 
 # Add a health check command
 HEALTHCHECK CMD node --version || exit 1

--- a/bit-tag-export/docker/Dockerfile
+++ b/bit-tag-export/docker/Dockerfile
@@ -4,9 +4,6 @@ FROM node:18-bullseye-slim
 # Install Bit CLI and other dependencies
 RUN npx @teambit/bvm install < /dev/null
 
-# Install Bit CLI using the bvm script
-RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/teambit/bvm/master/bvm.install.sh)"
-
 # Set Bit configurations
 RUN bit config set analytics_reporting false && \
     bit config set error_reporting false
@@ -17,7 +14,6 @@ ENTRYPOINT ["/entrypoint.sh"]
 # Copy the entrypoint script into the image
 COPY entrypoint.sh /entrypoint.sh
 
-USER root
 RUN chmod +x /entrypoint.sh
 USER user
 

--- a/bit-tag-export/docker/Dockerfile
+++ b/bit-tag-export/docker/Dockerfile
@@ -1,11 +1,11 @@
 # Use the official Node.js 18 image with Debian Bullseye (slim)
 FROM node:18-bullseye-slim
 
-# Install required dependencies
-RUN apt update && apt install -y curl
-
 # Install Bit CLI and other dependencies
 RUN npx @teambit/bvm install < /dev/null
+
+# Add Bit CLI to the PATH
+ENV PATH="/root/.bvm:${PATH}"
 
 # Set Bit configurations
 RUN bit config set analytics_reporting false && \
@@ -19,9 +19,6 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 USER user
-
-# Add Bit CLI to the PATH
-ENV PATH="/root/.bvm:${PATH}"
 
 # Add a health check command
 HEALTHCHECK CMD node --version || exit 1

--- a/bit-tag-export/docker/Dockerfile
+++ b/bit-tag-export/docker/Dockerfile
@@ -4,6 +4,9 @@ FROM node:18-bullseye-slim
 # Install Bit CLI and other dependencies
 RUN npx @teambit/bvm install < /dev/null
 
+# Install Bit CLI using the bvm script
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/teambit/bvm/master/bvm.install.sh)"
+
 # Set Bit configurations
 RUN bit config set analytics_reporting false && \
     bit config set error_reporting false


### PR DESCRIPTION
…  Dockerfile

The issue is that the bit command is not found inside the Docker container during the build process.

To address this,  I add the bit CLI installation script in your Dockerfile