### PR TITLE
feat: add claude-pr-review reusable workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -32,7 +32,7 @@ jobs:
             --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
 
   claude-auto-review:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action == 'review_requested'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,74 @@
+name: Claude PR Review
+
+on:
+  workflow_call:
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: true
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude-interactive:
+    if: |
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --model claude-opus-4-6
+            --max-turns 10
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
+
+  claude-auto-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            TRIGGER: ${{ github.event.action }}
+
+            You are reviewing a pull request. The PR branch is already checked out.
+
+            **Step 1: Determine context.**
+            - Run `gh pr view ${{ github.event.pull_request.number }} --json comments,reviews` to check for existing review comments.
+            - If this is a `synchronize` event (new push) AND there are existing review comments, this is a follow-up review. If this is an `opened` event or there are no prior comments, this is a fresh review.
+
+            **Step 2: Review accordingly.**
+
+            For a FRESH review (opened, no prior comments):
+            - Review the full PR diff with a focus on: code quality, potential bugs, security implications, and performance.
+            - Be thorough but concise. Group related feedback together.
+
+            For a FOLLOW-UP review (synchronize, prior comments exist):
+            - Run `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments` to read previous review comments.
+            - Focus on what changed in the latest push. Use `git log --oneline origin/${{ github.event.pull_request.base.ref }}..HEAD` to understand the commit history.
+            - Check if previous feedback was addressed. Acknowledge what was fixed.
+            - Only raise NEW issues or re-emphasize critical unresolved ones. Do not repeat feedback that was already addressed.
+            - If everything looks good, a brief "Changes look good, previous feedback addressed" is sufficient.
+
+            **Step 3: Post feedback.**
+            - Use `gh pr comment ${{ github.event.pull_request.number }}` for your feedback.
+            - Only post GitHub comments — don't submit review text as messages.
+          claude_args: |
+            --model claude-opus-4-6
+            --max-turns 10
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -55,18 +55,15 @@ jobs:
             **Step 2: Review accordingly.**
 
             For a FRESH review (opened, no prior comments):
-            - Review the full PR diff with a focus on: code quality, potential bugs, security implications, and performance.
-            - Only flag things that actually matter: bugs, security issues, meaningful design concerns.
-            - Skip nitpicks, style preferences, and minor suggestions. Do not comment on things that are fine.
-            - Use a single comment with short bullet points grouped by severity (bugs > security > design > other).
-            - If the PR looks good, just say so in 1-2 sentences. No need for a lengthy summary.
+            - Review the full PR diff for bugs, security issues, and meaningful design concerns.
+            - If the PR looks good, just comment "LGTM".
+            - If there are issues, use a single comment with short bullet points. Nothing else.
 
             For a FOLLOW-UP review (synchronize, prior comments exist):
             - Run `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments` to read previous review comments.
             - Focus on what changed in the latest push. Use `git log --oneline origin/${{ github.event.pull_request.base.ref }}..HEAD` to understand the commit history.
-            - Check if previous feedback was addressed.
-            - Only raise NEW issues or re-emphasize critical unresolved ones. Do not repeat addressed feedback.
-            - Keep it short: "Previous feedback addressed, LGTM" is a perfectly valid review.
+            - Do not repeat addressed feedback.
+            - If everything looks good, just comment "LGTM". If there are new issues, bullet points only.
 
             **Step 3: Post feedback.**
             - Use `gh pr comment ${{ github.event.pull_request.number }}` for your feedback.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -44,24 +44,23 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
-            TRIGGER: ${{ github.event.action }}
 
             You are reviewing a pull request. The PR branch is already checked out.
 
             **Step 1: Determine context.**
             - Run `gh pr view ${{ github.event.pull_request.number }} --json comments,reviews` to check for existing review comments.
-            - If this is a `synchronize` event (new push) AND there are existing review comments, this is a follow-up review. If this is an `opened` event or there are no prior comments, this is a fresh review.
+            - If there are prior review comments, this is a follow-up review. Otherwise it's a fresh review.
 
             **Step 2: Review accordingly.**
 
-            For a FRESH review (opened, no prior comments):
+            For a FRESH review (no prior review comments):
             - Review the full PR diff for bugs, security issues, and meaningful design concerns.
             - If the PR looks good, just comment "LGTM".
             - If there are issues, use a single comment with short bullet points. Nothing else.
 
-            For a FOLLOW-UP review (synchronize, prior comments exist):
+            For a FOLLOW-UP review (prior review comments exist):
             - Run `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments` to read previous review comments.
-            - Focus on what changed in the latest push. Use `git log --oneline origin/${{ github.event.pull_request.base.ref }}..HEAD` to understand the commit history.
+            - Check what changed since the last review. Use `git log --oneline origin/${{ github.event.pull_request.base.ref }}..HEAD` to understand the commit history.
             - Do not repeat addressed feedback.
             - If everything looks good, just comment "LGTM". If there are new issues, bullet points only.
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -56,18 +56,22 @@ jobs:
 
             For a FRESH review (opened, no prior comments):
             - Review the full PR diff with a focus on: code quality, potential bugs, security implications, and performance.
-            - Be thorough but concise. Group related feedback together.
+            - Only flag things that actually matter: bugs, security issues, meaningful design concerns.
+            - Skip nitpicks, style preferences, and minor suggestions. Do not comment on things that are fine.
+            - Use a single comment with short bullet points grouped by severity (bugs > security > design > other).
+            - If the PR looks good, just say so in 1-2 sentences. No need for a lengthy summary.
 
             For a FOLLOW-UP review (synchronize, prior comments exist):
             - Run `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments` to read previous review comments.
             - Focus on what changed in the latest push. Use `git log --oneline origin/${{ github.event.pull_request.base.ref }}..HEAD` to understand the commit history.
-            - Check if previous feedback was addressed. Acknowledge what was fixed.
-            - Only raise NEW issues or re-emphasize critical unresolved ones. Do not repeat feedback that was already addressed.
-            - If everything looks good, a brief "Changes look good, previous feedback addressed" is sufficient.
+            - Check if previous feedback was addressed.
+            - Only raise NEW issues or re-emphasize critical unresolved ones. Do not repeat addressed feedback.
+            - Keep it short: "Previous feedback addressed, LGTM" is a perfectly valid review.
 
             **Step 3: Post feedback.**
             - Use `gh pr comment ${{ github.event.pull_request.number }}` for your feedback.
             - Only post GitHub comments — don't submit review text as messages.
+            - Aim for the shortest useful review. Brevity is a feature.
           claude_args: |
             --model claude-opus-4-6
             --max-turns 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v7.5.0]
+
+### Added
+
+- `claude-pr-review` reusable workflow for automatic Claude Code PR reviews across repos
+
 ## [v7.4.2]
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Utility composite and docker actions for Parsley Workflows
 - [`setup-node`](./setup-node/README.md) replacement for `actions/setup-node`
 - [`db-init-action`](./db-init-action/README.md) replacement for `actions/setup-node`
 
+- [`claude-pr-review`](./.github/workflows/claude-pr-review.yml) reusable workflow for automatic Claude Code PR reviews (auto-review on PR open/push, interactive via `@claude` comments)
+
 ## Contributing
 
 - make sure to add documentation to a `README.md` in a well-named subfolder

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version=7.4.2
+version=7.5.0


### PR DESCRIPTION
## Summary

Adds a shared reusable workflow for Claude Code PR reviews across all Parsley repos. Instead of duplicating the full workflow config in each repo, repos use a thin caller file that references this shared workflow.

### Behavior
- **Auto-review** triggers when a reviewer is added to a PR (`review_requested`) — not on every push
- **Interactive** triggers when someone comments `@claude` on a PR
- **Context-aware**: fresh PRs get a full review, follow-up pushes only review new changes and don't repeat addressed feedback
- **Concise output**: "LGTM" if clean, bullet points if not

### Caller usage in consuming repos:

```yaml
name: Claude PR Review
on:
  issue_comment:
    types: [created]
  pull_request_review_comment:
    types: [created]
  pull_request:
    types: [review_requested]
    paths-ignore:
      - "**/*.md"
      - "docs/**"

jobs:
  review:
    uses: parsleyhealth/github-composite-actions/.github/workflows/claude-pr-review.yml@main
    secrets:
      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
```

## Test plan
- [ ] Merge and update one consuming repo to the caller pattern
- [ ] Add a reviewer to a PR and verify auto-review triggers
- [ ] Comment `@claude` on a PR and verify interactive review works
- [ ] Push a commit to a PR and verify it does NOT trigger a review

🤖 Generated with [Claude Code](https://claude.com/claude-code)